### PR TITLE
Create devfile.yaml

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -1,0 +1,16 @@
+schemaVersion: 2.2.0
+metadata:
+  name: hacbs-jvm-build-test-project
+  version: 1.1.0
+  provider: Red Hat
+  supportUrl: https://github.com/devfile-samples/devfile-support#support-information
+  displayName: hacbs-jvm-build-test-project
+  description: hacbs-jvm-build-test-project
+  tags: ["Java", "Maven"]
+  projectType: "maven"
+  language: "java"
+  attributes:
+    alpha.dockerimage-port: 8081
+parent:
+  id: java-maven
+  registryUrl: "https://registry.devfile.io"


### PR DESCRIPTION
required for https://github.com/redhat-appstudio/jvm-build-service/pull/161 and a follow-up test for [e2e-tests repo](https://github.com/redhat-appstudio/e2e-tests)

(discussed [here](https://github.com/redhat-appstudio/jvm-build-service/pull/161#pullrequestreview-1062450339))